### PR TITLE
Draft: DekoCompiler: Add OutputDkshToMemory method to output shader to memory

### DIFF
--- a/source/compiler_iface.h
+++ b/source/compiler_iface.h
@@ -39,6 +39,7 @@ public:
 
 	bool CompileGlsl(const char* glsl);
 	void OutputDksh(const char* dkshFile);
+	void OutputDkshToMemory(void *buffer, uint32_t *size);
 	void OutputRawCode(const char* rawFile);
 	void OutputTgsi(const char* tgsiFile);
 };


### PR DESCRIPTION
This will allow using UAM as a library (I'll add support for it in a future PR).

Marked as a draft because I think it would be better to add a `GetDkshSize` method so that the user can allocate a buffer of that exact size and then pass it to `OutputDkshToMemory`.